### PR TITLE
Update to documentation for yarn develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # grow-new-webstite
 
-
 Yarn install
 
-then run : gatsby develop
-
+then run : yarn develop
 
 Design -> https://zpl.io/2vOq1Or


### PR DESCRIPTION
Running `gatsby develop` requires gatsby to be installed globally.
Using `yarn develop` uses the local modules